### PR TITLE
to make the state of being "full" once again avaliable

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1051,6 +1051,8 @@ void Character::update_stomach( const time_point &from, const time_point &to )
     const bool calorie_deficit = has_calorie_deficit();
     const units::volume contains = stomach.contains();
     const units::volume cap = stomach.capacity( *this );
+    const trinary current_stomach_fullness = stomach.future_stomach_fullness( *this, 0_ml,
+            calorie_deficit );
 
     efftype_id hunger_effect;
     // i ate just now!
@@ -1065,9 +1067,9 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         // > 3/4 cap    full        full        full
         // > 1/2 cap    satisfied   v. hungry   famished/(near)starving
         // <= 1/2 cap   hungry      v. hungry   famished/(near)starving
-        if( stomach.would_be_engorged_with( *this, 0_ml, calorie_deficit ) ) {
+        if( current_stomach_fullness == trinary::ALL ) {            // we are engorged
             hunger_effect = effect_hunger_engorged;
-        } else if( stomach.would_be_full_with( *this, 0_ml, calorie_deficit ) ) {
+        } else if( current_stomach_fullness == trinary::SOME ) {    // we are just full
             hunger_effect = effect_hunger_full;
         } else if( just_ate && contains > cap / 2 ) {
             hunger_effect = effect_hunger_satisfied;
@@ -1090,9 +1092,9 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         // >= 3/8 cap   satisfied   satisfied   blank
         // > 0          blank       blank       blank
         // 0            blank       blank       (v.) hungry
-        if( stomach.would_be_engorged_with( *this, 0_ml, calorie_deficit ) ) {
+        if( current_stomach_fullness == trinary::ALL ) {            // we are engorged
             hunger_effect = effect_hunger_engorged;
-        } else if( stomach.would_be_full_with( *this, 0_ml, calorie_deficit ) ) {
+        } else if( current_stomach_fullness == trinary::SOME ) {    // we are just full
             hunger_effect = effect_hunger_full;
         } else if( recently_ate && contains >= cap * 3 / 8 ) {
             hunger_effect = effect_hunger_satisfied;

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -313,28 +313,18 @@ units::volume stomach_contents::stomach_remaining( const Character &owner ) cons
     return capacity( owner ) - contents - water;
 }
 
-bool stomach_contents::would_be_engorged_with( const Character &owner, units::volume intake,
+trinary stomach_contents::future_stomach_fullness( const Character &owner, units::volume intake,
         bool calorie_deficit ) const
 {
-    const double fullness_ratio = ( contains() + intake ) / capacity( owner );
-    if( calorie_deficit && fullness_ratio >= 1.0 ) {
-        return true;
-    } else if( fullness_ratio >= 5.0 / 6.0 ) {
-        return true;
+    const double future_contents = to_milliliter( contains() + intake );
+    const double future_fullness_ratio = future_contents / to_milliliter( capacity( owner ) );
+    if( future_fullness_ratio >= ( calorie_deficit ? 1.0 : 5.0 / 6.0 ) ) {  // thresholds for engorged
+        return trinary::ALL;    // will be engorged
+    } else if( future_fullness_ratio >= ( calorie_deficit ? 0.75 : 0.55 ) ) {   // thresholds for full
+        return trinary::SOME;   // will become full
+    } else {
+        return trinary::NONE;   // won't become full
     }
-    return false;
-}
-
-bool stomach_contents::would_be_full_with( const Character &owner, units::volume intake,
-        bool calorie_deficit ) const
-{
-    const double fullness_ratio = ( contains() + intake ) / capacity( owner );
-    if( calorie_deficit && fullness_ratio >= 11.0 / 20.0 ) {
-        return true;
-    } else if( fullness_ratio >= 3.0 / 4.0 ) {
-        return true;
-    }
-    return false;
 }
 
 units::volume stomach_contents::contains() const

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -165,9 +165,13 @@ class stomach_contents
          */
         units::volume capacity( const Character &owner ) const;
         // These functions need a ref to the stomach's owner because capacity() does
-        bool would_be_engorged_with( const Character &owner, units::volume intake,
-                                     bool calorie_deficit ) const;
-        bool would_be_full_with( const Character &owner, units::volume intake, bool calorie_deficit ) const;
+        // this function checks if consuming an item would make you overeat (with emetic consequences)
+        // trinary::ALL means the player will become engorged
+        // trinary::SOME for just full
+        // trinary::NONE for everything else
+        trinary future_stomach_fullness( const Character &owner, units::volume intake,
+                                         bool calorie_deficit ) const;
+
         // how much stomach capacity you have left before you puke from stuffing your gob
         units::volume stomach_remaining( const Character &owner ) const;
         // how much volume is in the stomach_contents

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -206,7 +206,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     set_time( midday );
 
     const tripoint test_origin( 60, 60, 0 );
-    const int water_charges = 8;
+    const int water_charges = 5;
     Character &character = get_player_character();
     const item backpack( "backpack" );
     character.wear_item( backpack );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

review in PR form, basically

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

made the hunger-checking functions a trinary, that with different states of output (ALL, SOME and NONE for Engorged, Full and otherwise, respectively) being used to uniformly determine the things that ask for hunger

the function is named "future_stomach_fullness", but by inputting 0_ml as the "future food" it is the same as asking for the current fullness.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

right now, only by messing with the amount of water charges that is supposed to be in the test (set to 5) can I get it to work. the fact there is a solution to the equation (properly empty the tank + be full) tells me that it is a valid fix

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->

I hope specifically this PR doesn't land in the original repository, that would be pretty embarrassing
